### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,12 +13,12 @@ module.exports = {
   entry: entries,
   output: {
     filename: "[name]/[name].js",
-    publicPath: "/dist/"
   },
   devtool: "inline-source-map",
   devServer: {
     https: true,
-    port: 3000
+    port: 3000,
+    publicPath: "/dist/"
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js"],


### PR DESCRIPTION
When you use lazy load for modules new js gen into dist/dist/[name]/[name].js, because dist is default output folder.