### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 // ...
 
 module.exports = {
-  plugins: [new CopyWebpackPlugin([{ from: "**/*.html", context: "src" }])],
+  plugins: [new CopyWebpackPlugin({ patterns: [{ from: "**/*.html", context: "src"}] })],
   // ...
 };
 ```


### PR DESCRIPTION
The instructions for enabling hot reload on an existing project are not up to date. The `webpack.config.json` got updated by #53, but the README wasn't. 